### PR TITLE
Game log observer: commands and orders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ add_executable(comp_345
 	src/CommandProcessingDriver.cpp
 	src/GameEngine.cpp
 	src/GameEngineDriver.cpp
+	src/LoggingObserver.cpp
+	src/LoggingObserverDriver.cpp
 	src/MainDriver.cpp
 	src/Map.cpp
 	src/MapDriver.cpp

--- a/src/CommandProcessing.h
+++ b/src/CommandProcessing.h
@@ -4,20 +4,16 @@
 #include <string>
 #include <vector>
 
+#include "LoggingObserver.h"
 
 // forward declarations
 class GameEngine;
-
-class Command;
-class CommandProcessor;
-class FileLineReader;
-class FileCommandProcessorAdapter;
 
 /**
  * The Command class represents a game command with its associated effect.
  * It stores the command string and the effect of executing that command.
  */
-class Command {
+class Command : public Subject, public ILoggable {
 private:
   std::string* command; // the command string
   std::string* effect;  // the effect/result of the command
@@ -35,7 +31,8 @@ public:
   std::string getEffect() const;
 
   // utility
-  void saveEffect(const std::string& eff) const;
+  void saveEffect(const std::string& eff);
+  std::string stringToLog() const override;
 
   // stream insertion
   friend std::ostream& operator<<(std::ostream& os, const Command& cmd);
@@ -47,9 +44,10 @@ public:
  * The commands can be read from the console or overridden by subclasses.
  * Game components must get their commands from this processor.
  */
-class CommandProcessor {
+class CommandProcessor : public Subject, public ILoggable {
 private:
   std::vector<Command*>* commands; // a collection of command objects
+  Command* lastSavedCommand;
 
 public:
   CommandProcessor();
@@ -64,6 +62,7 @@ public:
   // utility
   void saveCommand(Command* cmd);
   bool validate(const std::string& cmd, const GameEngine* engine) const;
+  std::string stringToLog() const override;
 
   // stream insertion
   friend std::ostream& operator<<(std::ostream& os, const CommandProcessor& cp);

--- a/src/GameEngine.h
+++ b/src/GameEngine.h
@@ -6,6 +6,8 @@
 #include <map>
 #include <memory>   
 
+#include "LoggingObserver.h"
+
 
 class State;
 class Transition;
@@ -15,7 +17,7 @@ class Player;
 class Deck;
 class CommandProcessor;
 
-class GameEngine {
+class GameEngine : public Subject, public ILoggable {
 private:
     State* currentState;
     std::map<std::string, State*>* states;
@@ -35,10 +37,11 @@ public:
     friend std::ostream& operator<<(std::ostream& os, const GameEngine& engine);
 
     void processCommand(const std::string& command);
-    void transitionTo(const std::string& stateName);
+    void transitionState(const std::string& stateName);
     std::string getCurrentStateName() const;
     void displayValidCommands() const;
     void displayStateHistory() const;
+    std::string stringToLog() const override;
 
     void startupPhase();
     void startupPhase(CommandProcessor&);

--- a/src/LoggingObserver.cpp
+++ b/src/LoggingObserver.cpp
@@ -1,0 +1,155 @@
+#include "LoggingObserver.h"
+
+#include <algorithm>
+#include <iostream>
+
+// ===== Observer =====
+Observer::Observer() = default;
+
+Observer::Observer(const Observer& other) {
+    (void)other;
+}
+
+Observer::~Observer() = default;
+
+Observer& Observer::operator=(const Observer& other) {
+    if (this != &other) {
+        (void)other;
+    }
+    return *this;
+}
+
+// ===== Subject =====
+Subject::Subject() {
+    observers = new std::vector<Observer*>();
+}
+
+Subject::Subject(const Subject& other) {
+    observers = new std::vector<Observer*>(*other.observers);
+}
+
+Subject::~Subject() {
+    delete observers;
+}
+
+Subject& Subject::operator=(const Subject& other) {
+    if (this != &other) {
+        delete observers;
+        observers = new std::vector<Observer*>(*other.observers);
+    }
+    return *this;
+}
+
+void Subject::attach(Observer* observer) {
+    if (!observer) {
+        return;
+    }
+    for (Observer* existing : *observers) {
+        if (existing == observer) {
+            return;
+        }
+    }
+    observers->push_back(observer);
+}
+
+void Subject::detach(Observer* observer) {
+    if (!observer) {
+        return;
+    }
+    observers->erase(
+        std::remove(observers->begin(), observers->end(), observer),
+        observers->end());
+}
+
+void Subject::notify() {
+    for (Observer* observer : *observers) {
+        if (observer) {
+            observer->update(this);
+        }
+    }
+}
+
+// ===== LogObserver =====
+LogObserver::LogObserver() {
+    logfile = new std::ofstream();
+    openLog();
+}
+
+LogObserver::LogObserver(const LogObserver& other) : Observer(other) {
+    logfile = new std::ofstream();
+    openLog();
+    if (other.logfile && other.logfile->is_open()) {
+        (*logfile) << std::flush;
+    }
+}
+
+LogObserver::~LogObserver() {
+    closeLog();
+    delete logfile;
+}
+
+LogObserver& LogObserver::operator=(const LogObserver& other) {
+    if (this != &other) {
+        closeLog();
+        if (!logfile) {
+            logfile = new std::ofstream();
+        }
+        openLog();
+        if (other.logfile && other.logfile->is_open()) {
+            (*logfile) << std::flush;
+        }
+    }
+    return *this;
+}
+
+std::ostream& operator<<(std::ostream& os, const LogObserver& observer) {
+    os << "LogObserver writing to gamelog.txt";
+    if (observer.logfile && observer.logfile->is_open()) {
+        os << " (open)";
+    } else {
+        os << " (closed)";
+    }
+    return os;
+}
+
+void LogObserver::update(Subject* subject) {
+    if (!subject) {
+        return;
+    }
+
+    ILoggable* loggable = dynamic_cast<ILoggable*>(subject);
+    if (!loggable) {
+        return;
+    }
+
+    if (!logfile || !logfile->is_open()) {
+        openLog();
+    }
+
+    if (logfile && logfile->is_open()) {
+        (*logfile) << loggable->stringToLog() << std::endl;
+        logfile->flush();
+    }
+}
+
+void LogObserver::openLog() {
+    if (!logfile) {
+        return;
+    }
+
+    if (logfile->is_open()) {
+        return;
+    }
+
+    logfile->open("gamelog.txt", std::ios::out | std::ios::app);
+    if (!(*logfile)) {
+        std::cerr << "Unable to open gamelog.txt for writing." << std::endl;
+    }
+}
+
+void LogObserver::closeLog() {
+    if (logfile && logfile->is_open()) {
+        logfile->close();
+    }
+}
+

--- a/src/LoggingObserver.h
+++ b/src/LoggingObserver.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <fstream>
+#include <ostream>
+#include <string>
+#include <vector>
+
+class Subject;
+
+class ILoggable {
+public:
+    virtual std::string stringToLog() const = 0;
+    virtual ~ILoggable() = default;
+};
+
+class Observer {
+public:
+    Observer();
+    Observer(const Observer& other);
+    virtual ~Observer();
+    Observer& operator=(const Observer& other);
+
+    virtual void update(Subject* subject) = 0;
+};
+
+class Subject {
+public:
+    Subject();
+    Subject(const Subject& other);
+    virtual ~Subject();
+    Subject& operator=(const Subject& other);
+
+    void attach(Observer* observer);
+    void detach(Observer* observer);
+    void notify();
+
+protected:
+    std::vector<Observer*>* observers;
+};
+
+class LogObserver : public Observer {
+public:
+    LogObserver();
+    LogObserver(const LogObserver& other);
+    ~LogObserver() override;
+
+    LogObserver& operator=(const LogObserver& other);
+    friend std::ostream& operator<<(std::ostream& os, const LogObserver& observer);
+
+    void update(Subject* subject) override;
+
+private:
+    std::ofstream* logfile;
+
+    void openLog();
+    void closeLog();
+};
+

--- a/src/LoggingObserverDriver.cpp
+++ b/src/LoggingObserverDriver.cpp
@@ -1,0 +1,70 @@
+#include "LoggingObserver.h"
+#include "CommandProcessing.h"
+#include "Orders.h"
+#include "GameEngine.h"
+#include "Player.h"
+#include "Map.h"
+
+#include <fstream>
+#include <iostream>
+
+void testLoggingObserver() {
+  std::cout << "=== Logging Observer Test ===" << std::endl;
+
+  // Reset log file
+  std::ofstream clearFile("gamelog.txt", std::ios::trunc);
+  clearFile.close();
+
+  LogObserver logger;
+
+  // ---- Command logging ----
+  CommandProcessor processor;
+  processor.attach(&logger);
+
+  Command* cmdLoadMap = new Command("loadmap World.map");
+  processor.saveCommand(cmdLoadMap);
+  cmdLoadMap->saveEffect("Loaded map World.map");
+
+  Command* cmdValidate = new Command("validatemap");
+  processor.saveCommand(cmdValidate);
+  cmdValidate->saveEffect("Map validated successfully");
+
+  // ---- Order logging ----
+  OrdersList ordersList;
+  ordersList.attach(&logger);
+
+  Player playerOne("Alice");
+  Player playerTwo("Bob");
+  Territory territoryAlpha("Alpha", 1);
+  Territory territoryBeta("Beta", 2);
+
+  territoryAlpha.addAdjacentTerritory(&territoryBeta);
+  territoryBeta.addAdjacentTerritory(&territoryAlpha);
+
+  playerOne.addTerritory(&territoryAlpha);
+  territoryAlpha.setOwner(&playerOne);
+  playerOne.setReinforcementPool(10);
+
+  playerTwo.addTerritory(&territoryBeta);
+  territoryBeta.setOwner(&playerTwo);
+
+  int deployArmies = 5;
+  OrderDeploy* deployOrder = new OrderDeploy(&playerOne, &territoryAlpha, &deployArmies);
+  ordersList.add(deployOrder);
+  deployOrder->execute();
+
+  int advanceArmies = 3;
+  OrderAdvance* advanceOrder = new OrderAdvance(&playerOne, &territoryAlpha, &territoryBeta, &advanceArmies);
+  ordersList.add(advanceOrder);
+  advanceOrder->execute();
+
+  // ---- Game engine logging ----
+  GameEngine engine;
+  engine.attach(&logger);
+  engine.transitionState("start");
+  engine.transitionState("map loaded");
+  engine.transitionState("map validated");
+
+  std::cout << "Logging complete. Review gamelog.txt for entries." << std::endl;
+}
+

--- a/src/MainDriver.cpp
+++ b/src/MainDriver.cpp
@@ -8,6 +8,7 @@ void testCards();
 void testGameStates();
 void testCommandProcessor();
 void testStartupPhase();
+void testLoggingObserver();
 
 /**
  * The Main driver function that calls all test functions for each part
@@ -62,6 +63,11 @@ int main() {
     std::cout << "PART 6: STARTUP PHASE TESTING" << std::endl;
     std::cout << std::string(50, '=') << std::endl;
     testStartupPhase();
+
+    std::cout << "\n" << std::string(50, '=') << std::endl;
+    std::cout << "PART 7: LOGGING OBSERVER TESTING" << std::endl;
+    std::cout << std::string(50, '=') << std::endl;
+    testLoggingObserver();
 
     std::cout << "\n" << std::string(50, '=') << std::endl;
     std::cout << "ALL TESTS COMPLETED SUCCESSFULLY" << std::endl;

--- a/src/Orders.cpp
+++ b/src/Orders.cpp
@@ -4,9 +4,36 @@ std::unique_ptr<std::vector<NegotiationRecord>> Order::negotiationRecords = std:
 
 // Base Order
 Order::Order():
+  Subject(),
   type{nullptr},
-  description{nullptr}
+  description{nullptr},
+  effect{new std::string("")}
   {}
+
+Order::Order(const Order& other) :
+  Subject(other),
+  type(other.type ? new std::string(*other.type) : nullptr),
+  description(other.description ? new std::string(*other.description) : nullptr),
+  effect(other.effect ? new std::string(*other.effect) : new std::string("")) {}
+
+Order& Order::operator=(const Order& other) {
+  if (this != &other) {
+    Subject::operator=(other);
+    delete type;
+    delete description;
+    delete effect;
+    type = other.type ? new std::string(*other.type) : nullptr;
+    description = other.description ? new std::string(*other.description) : nullptr;
+    effect = other.effect ? new std::string(*other.effect) : new std::string("");
+  }
+  return *this;
+}
+
+Order::~Order() {
+  delete type;
+  delete description;
+  delete effect;
+}
 
 std::ostream& operator<<(std::ostream& os, const Order& order) { 
   if (!order.type || !order.description) {
@@ -22,8 +49,27 @@ void Order::clearNegotiationRecords() {
   negotiationRecords->clear();
 }
 
+void Order::saveEffect(const std::string& effectDescription) {
+  if (!effect) {
+    effect = new std::string(effectDescription);
+  } else {
+    *effect = effectDescription;
+  }
+  notify();
+}
+
+std::string Order::getEffect() const {
+  return effect ? *effect : "";
+}
+
+std::string Order::stringToLog() const {
+  const std::string typeName = type ? *type : "<unknown>";
+  const std::string effectText = effect ? *effect : "<no effect>";
+  return "Order [" + typeName + "] effect: " + effectText;
+}
+
 //  OrderDeploy
-OrderDeploy::OrderDeploy(Player* player, Territory* target, int* soldiers) {
+OrderDeploy::OrderDeploy(Player* player, Territory* target, int* soldiers) : Order() {
   this->player = player;
   this->target = target;
   this->soldiers = soldiers;
@@ -31,7 +77,7 @@ OrderDeploy::OrderDeploy(Player* player, Territory* target, int* soldiers) {
   description = new std::string("Deploys armies to a specified territory you own.");
 }
 
-OrderDeploy::OrderDeploy(const OrderDeploy& other) {
+OrderDeploy::OrderDeploy(const OrderDeploy& other) : Order(other) {
   this->player = other.player;
   this->target = other.target;
   this->soldiers = other.soldiers;
@@ -39,17 +85,11 @@ OrderDeploy::OrderDeploy(const OrderDeploy& other) {
   description = new std::string(*(other.description));
 }
 
-OrderDeploy::~OrderDeploy() {
-  delete type;
-  delete description;
-}
+OrderDeploy::~OrderDeploy() = default;
 
 OrderDeploy& OrderDeploy::operator=(const OrderDeploy& other) { 
   if (this != &other) {
-    delete type;
-    delete description;
-    type = new std::string(*(other.type));
-    description = new std::string(*(other.description));
+    Order::operator=(other);
     this->player = other.player;
     this->target = other.target;
     this->soldiers = other.soldiers;
@@ -68,11 +108,14 @@ bool OrderDeploy::validate() {
 }
 
 void OrderDeploy::execute() {
-  if (this->validate())
-  {
-    target->setArmies(target->getArmies() + *soldiers);
-    player->setReinforcementPool(player->getReinforcementPool() - *soldiers);
+  if (!this->validate()) {
+    saveEffect("Deploy order invalid. Not executed.");
+    return;
   }
+
+  target->setArmies(target->getArmies() + *soldiers);
+  player->setReinforcementPool(player->getReinforcementPool() - *soldiers);
+  saveEffect("Deployed " + std::to_string(*soldiers) + " armies to " + target->getName() + ".");
 }
 
 Order* OrderDeploy::clone() const { 
@@ -81,7 +124,7 @@ Order* OrderDeploy::clone() const {
 
 
 //  OrderAdvance 
-OrderAdvance::OrderAdvance(Player* player, Territory* source, Territory* target, int* soldiers) {
+OrderAdvance::OrderAdvance(Player* player, Territory* source, Territory* target, int* soldiers) : Order() {
   this->player = player;
   this->source = source;
   this->target = target;
@@ -90,7 +133,7 @@ OrderAdvance::OrderAdvance(Player* player, Territory* source, Territory* target,
   description = new std::string("Moves armies from one territory to another, can also be used to attack enemy territories.");
 }
 
-OrderAdvance::OrderAdvance(const OrderAdvance& other) {
+OrderAdvance::OrderAdvance(const OrderAdvance& other) : Order(other) {
   this->player = other.player;
   this->source = other.source;
   this->target = other.target;
@@ -99,17 +142,11 @@ OrderAdvance::OrderAdvance(const OrderAdvance& other) {
   description = new std::string(*(other.description));
 }
 
-OrderAdvance::~OrderAdvance() {
-  delete type;
-  delete description;
-}
+OrderAdvance::~OrderAdvance() = default;
 
 OrderAdvance& OrderAdvance::operator=(const OrderAdvance& other) { 
   if (this != &other) {
-    delete type;
-    delete description;
-    type = new std::string(*(other.type));
-    description = new std::string(*(other.description));
+    Order::operator=(other);
     this->player = other.player;
     this->source = other.source;
     this->target = other.target;
@@ -130,61 +167,64 @@ bool OrderAdvance::validate() {
     }
     return true;
   }else{
+    saveEffect("Advance order invalid.");
     return false;
   }
 }
 
 void OrderAdvance::execute() {
-  if(this->validate()){
-    std::cout << "Executing Advance Order: Moving " << *soldiers << " armies from " << source->getName() << " to " << target->getName() << ".\n";
-    if (player->ownsTerritory(target)){
-      source->setArmies(source->getArmies() - *soldiers);
-      target->setArmies(target->getArmies() + *soldiers);
-    } else {
-      // Remove soldiers from source territory
-      source->setArmies(source->getArmies() - *soldiers);
+  if(!this->validate()){
+    saveEffect("Advance order invalid. Not executed.");
+    return;
+  }
+  std::cout << "Executing Advance Order: Moving " << *soldiers << " armies from " << source->getName() << " to " << target->getName() << ".\n";
+  if (player->ownsTerritory(target)){
+    source->setArmies(source->getArmies() - *soldiers);
+    target->setArmies(target->getArmies() + *soldiers);
+    saveEffect("Advanced armies to friendly territory " + target->getName() + ".");
+  } else {
+    // Remove soldiers from source territory
+    source->setArmies(source->getArmies() - *soldiers);
 
-      int attackers = *soldiers;
-      int defenders = target->getArmies();
+    int attackers = *soldiers;
+    int defenders = target->getArmies();
 
-      int attackSuccesses = 0;
-      int defenseSuccesses = 0;
+    int attackSuccesses = 0;
+    int defenseSuccesses = 0;
 
-      for (int i = 0; i < *soldiers; i++) {
-        if((rand() % 100) < 60) {
-          attackSuccesses++;
-        }
-      }
-
-      for (int i = 0; i < target->getArmies(); i++) {
-        if((rand() % 100) < 70) {
-          defenseSuccesses++;
-        }
-      }
-
-      attackers -= defenseSuccesses;
-      defenders -= attackSuccesses;
-
-      if(defenders <= 0){
-          player->setConqueredThisTurn(true);
-          player->addTerritory(target);
-          target->setOwner(player);
-          if(attackers < 0){
-            attackers = 1; // At least one army must occupy the conquered territory
-            // Rare edge case where all attackers die but defenders also die
-          }
-          target->setArmies(attackers);
-      } else {
-        target->setArmies(defenders);
-        if(attackers >= 0){
-          source->setArmies(source->getArmies() + attackers); // Return surviving attackers back to source
-        }
+    for (int i = 0; i < *soldiers; i++) {
+      if((rand() % 100) < 60) {
+        attackSuccesses++;
       }
     }
-  }else{
-    std::cout << "Advance Order validation failed. Order not executed.\n";
-  }
 
+    for (int i = 0; i < target->getArmies(); i++) {
+      if((rand() % 100) < 70) {
+        defenseSuccesses++;
+      }
+    }
+
+    attackers -= defenseSuccesses;
+    defenders -= attackSuccesses;
+
+    if(defenders <= 0){
+        player->setConqueredThisTurn(true);
+        player->addTerritory(target);
+        target->setOwner(player);
+        if(attackers < 0){
+          attackers = 1; // At least one army must occupy the conquered territory
+          // Rare edge case where all attackers die but defenders also die
+        }
+        target->setArmies(attackers);
+        saveEffect("Advance order succeeded and conquered " + target->getName() + ".");
+    } else {
+      target->setArmies(defenders);
+      if(attackers >= 0){
+        source->setArmies(source->getArmies() + attackers); // Return surviving attackers back to source
+      }
+      saveEffect("Advance order failed to conquer " + target->getName() + ".");
+    }
+  }
 }
 
 Order* OrderAdvance::clone() const { 
@@ -193,31 +233,25 @@ Order* OrderAdvance::clone() const {
 
 
 //  OrderBomb 
-OrderBomb::OrderBomb(Territory* target, Player* player) {
+OrderBomb::OrderBomb(Territory* target, Player* player) : Order() {
   this->target = target;
   this->player = player;
   type = new std::string("bomb");
   description = new std::string("Destroys half the armies on an enemy territory, can only be used once per game.");
 }
 
-OrderBomb::OrderBomb(const OrderBomb& other) {
+OrderBomb::OrderBomb(const OrderBomb& other) : Order(other) {
   this->target = other.target;
   this->player = other.player;
   type = new std::string(*(other.type));
   description = new std::string(*(other.description));
 }
 
-OrderBomb::~OrderBomb() {
-  delete type;
-  delete description;
-}
+OrderBomb::~OrderBomb() = default;
 
 OrderBomb& OrderBomb::operator=(const OrderBomb& other) { 
   if (this != &other) {
-    delete type;
-    delete description;
-    type = new std::string(*(other.type));
-    description = new std::string(*(other.description));
+    Order::operator=(other);
     this->target = other.target;
     this->player = other.player;
   }
@@ -233,15 +267,20 @@ bool OrderBomb::validate() {
     }
     return false;
   }else {
+    saveEffect("Bomb order invalid.");
     return false;
   }
 }
 
 void OrderBomb::execute() {
-  if (this->validate())
+  if (!this->validate())
   {
-    target->setArmies(target->getArmies() / 2);
+    saveEffect("Bomb order invalid. Not executed.");
+    return;
   }
+
+  target->setArmies(target->getArmies() / 2);
+  saveEffect("Bombed " + target->getName() + "; armies halved.");
 }
 
 Order* OrderBomb::clone() const { 
@@ -250,7 +289,7 @@ Order* OrderBomb::clone() const {
 
 
 //  OrderBlockade 
-OrderBlockade::OrderBlockade(Player* nPlayer, Player* player, Territory* target) {
+OrderBlockade::OrderBlockade(Player* nPlayer, Player* player, Territory* target) : Order() {
   this->nPlayer = nPlayer;
   this->player = player;
   this->target = target;
@@ -258,7 +297,7 @@ OrderBlockade::OrderBlockade(Player* nPlayer, Player* player, Territory* target)
   description = new std::string("Triples the armies on one of your territories and makes it neutral, can only be used once per game.");
 }
 
-OrderBlockade::OrderBlockade(const OrderBlockade& other) {
+OrderBlockade::OrderBlockade(const OrderBlockade& other) : Order(other) {
   this->nPlayer = other.nPlayer;
   this->player = other.player;
   this->target = other.target;
@@ -266,17 +305,11 @@ OrderBlockade::OrderBlockade(const OrderBlockade& other) {
   description = new std::string(*(other.description));
 }
 
-OrderBlockade::~OrderBlockade() {
-  delete type;
-  delete description;
-}
+OrderBlockade::~OrderBlockade() = default;
 
 OrderBlockade& OrderBlockade::operator=(const OrderBlockade& other) { 
   if (this != &other) {
-    delete type;
-    delete description;
-    type = new std::string(*(other.type));
-    description = new std::string(*(other.description));
+    Order::operator=(other);
     this->nPlayer = other.nPlayer;
     this->player = other.player;
     this->target = other.target;
@@ -288,18 +321,23 @@ bool OrderBlockade::validate() {
   if (target && player->ownsTerritory(target)) {
     return true;
   }else {
+    saveEffect("Blockade order invalid.");
     return false;
   }
 }
 
 void OrderBlockade::execute() {
-  if (this->validate())
+  if (!this->validate())
   {
-    target->setArmies(target->getArmies() * 2);
-    player->removeTerritory(target);
-    nPlayer->addTerritory(target);
-    target->setOwner(nPlayer);
+    saveEffect("Blockade order invalid. Not executed.");
+    return;
   }
+
+  target->setArmies(target->getArmies() * 2);
+  player->removeTerritory(target);
+  nPlayer->addTerritory(target);
+  target->setOwner(nPlayer);
+  saveEffect("Blockade executed on " + target->getName() + "; territory becomes neutral.");
 }
 
 Order* OrderBlockade::clone() const { 
@@ -308,7 +346,7 @@ Order* OrderBlockade::clone() const {
 
 
 //  OrderAirlift 
-OrderAirlift::OrderAirlift(Player* player, Territory* source, Territory* target, int* soldiers) {
+OrderAirlift::OrderAirlift(Player* player, Territory* source, Territory* target, int* soldiers) : Order() {
   this->player = player;
   this->source = source;
   this->target = target;
@@ -317,7 +355,7 @@ OrderAirlift::OrderAirlift(Player* player, Territory* source, Territory* target,
   description = new std::string("Moves any number of armies from one of your territories to another territory you own, can only be used once per game.");
 }
 
-OrderAirlift::OrderAirlift(const OrderAirlift& other) {
+OrderAirlift::OrderAirlift(const OrderAirlift& other) : Order(other) {
   this->player = other.player;
   this->source = other.source;
   this->target = other.target;
@@ -326,17 +364,11 @@ OrderAirlift::OrderAirlift(const OrderAirlift& other) {
   description = new std::string(*(other.description));
 }
 
-OrderAirlift::~OrderAirlift() {
-  delete type;
-  delete description;
-}
+OrderAirlift::~OrderAirlift() = default;
 
 OrderAirlift& OrderAirlift::operator=(const OrderAirlift& other) { 
   if (this != &other) {
-    delete type;
-    delete description;
-    type = new std::string(*(other.type));
-    description = new std::string(*(other.description));
+    Order::operator=(other);
     this->player = other.player;
     this->source = other.source;
     this->target = other.target;
@@ -349,15 +381,20 @@ bool OrderAirlift::validate() {
   if (source && target && player->ownsTerritory(source) && player->ownsTerritory(target) && *soldiers > 0 && source->getArmies() >= *soldiers ) {
     return true;
   }else{
+    saveEffect("Airlift order invalid.");
     return false;
   }
 }
 
 void OrderAirlift::execute() {
-  if(this->validate()){
-    source->setArmies(source->getArmies() - *soldiers);
-    target->setArmies(target->getArmies() + *soldiers);
+  if(!this->validate()){
+    saveEffect("Airlift order invalid. Not executed.");
+    return;
   }
+
+  source->setArmies(source->getArmies() - *soldiers);
+  target->setArmies(target->getArmies() + *soldiers);
+  saveEffect("Airlifted " + std::to_string(*soldiers) + " armies to " + target->getName() + ".");
 }
 
 Order* OrderAirlift::clone() const { 
@@ -366,31 +403,25 @@ Order* OrderAirlift::clone() const {
 
 
 //  OrderNegotiate 
-OrderNegotiate::OrderNegotiate(Player* player, Player* targetPlayer) {
+OrderNegotiate::OrderNegotiate(Player* player, Player* targetPlayer) : Order() {
   this->player = player;
   this->targetPlayer = targetPlayer;
   type = new std::string("negotiate");
   description = new std::string("Prevents attacks between you and another player until your next turn, can only be used once per game.");
 }
 
-OrderNegotiate::OrderNegotiate(const OrderNegotiate& other) {
+OrderNegotiate::OrderNegotiate(const OrderNegotiate& other) : Order(other) {
   this->player = other.player;
   this->targetPlayer = other.targetPlayer;
   type = new std::string(*(other.type));
   description = new std::string(*(other.description));
 }
 
-OrderNegotiate::~OrderNegotiate() {
-  delete type;
-  delete description;
-}
+OrderNegotiate::~OrderNegotiate() = default;
 
 OrderNegotiate& OrderNegotiate::operator=(const OrderNegotiate& other) { 
   if (this != &other) {
-    delete type;
-    delete description;
-    type = new std::string(*(other.type));
-    description = new std::string(*(other.description));
+    Order::operator=(other);
     this->player = other.player;
     this->targetPlayer = other.targetPlayer;
   }
@@ -401,15 +432,20 @@ bool OrderNegotiate::validate() {
   if (targetPlayer && targetPlayer != player) {
     return true;
   }else {
+    saveEffect("Negotiate order invalid.");
     return false;
   }
 }
 
 void OrderNegotiate::execute() {
-  if (this->validate())
+  if (!this->validate())
   {
-    this->negotiationRecords->push_back(NegotiationRecord{player, targetPlayer});
+    saveEffect("Negotiate order invalid. Not executed.");
+    return;
   }
+
+  this->negotiationRecords->push_back(NegotiationRecord{player, targetPlayer});
+  saveEffect("Negotiation established between " + player->getName() + " and " + targetPlayer->getName() + ".");
 }
 
 Order* OrderNegotiate::clone() const { 
@@ -418,24 +454,26 @@ Order* OrderNegotiate::clone() const {
 
 
 //  OrdersList 
-OrdersList::OrdersList() {
-  orders = new std::vector<Order*>();
+OrdersList::OrdersList() : Subject(), orders(new std::vector<Order*>()), lastAddedOrder(nullptr) {
 }
 
-OrdersList::OrdersList(const OrdersList& other) {
+OrdersList::OrdersList(const OrdersList& other) : Subject(other) {
   orders = new std::vector<Order*>();
   for (const auto& order : *other.orders) {
     orders->push_back(order->clone());
   }
+  lastAddedOrder = orders->empty() ? nullptr : orders->back();
 }
 
 OrdersList& OrdersList::operator=(const OrdersList& other) {
   if (this != &other) {
+    Subject::operator=(other);
     delete orders;
     orders = new std::vector<Order*>();
     for (const auto& order : *other.orders) {
       orders->push_back(order->clone());
     }
+    lastAddedOrder = orders->empty() ? nullptr : orders->back();
   }
   return *this;
 }
@@ -454,6 +492,13 @@ bool OrdersList::validateIndex(int index) {
 
 void OrdersList::add(Order* order) {
   orders->push_back(order);
+  lastAddedOrder = order;
+  if (order) {
+    for (Observer* observer : *observers) {
+      order->attach(observer);
+    }
+  }
+  notify();
 }
 
 void OrdersList::remove(int index) {
@@ -483,5 +528,12 @@ OrdersList::~OrdersList() {
   }
 
   delete orders;
+}
+
+std::string OrdersList::stringToLog() const {
+  if (lastAddedOrder) {
+    return "OrdersList added order: " + lastAddedOrder->stringToLog();
+  }
+  return "OrdersList updated.";
 }
 

--- a/src/Orders.h
+++ b/src/Orders.h
@@ -6,6 +6,8 @@
 #include <iostream>
 #include <memory>
 
+#include "LoggingObserver.h"
+
 struct NegotiationRecord {
     Player* player1;
     Player* player2;
@@ -14,9 +16,11 @@ struct NegotiationRecord {
 /*
 Abstract base class for all order types.
 */
-class Order {
+class Order : public Subject, public ILoggable {
 public:
   Order();
+  Order(const Order& other);
+  Order& operator=(const Order& other);
 
   // validates an order is valid based on the current gamestate
   virtual bool validate() = 0;
@@ -26,13 +30,17 @@ public:
   virtual Order* clone() const = 0;
 
   //Make destructor virtual to avoid memory leaks
-  virtual ~Order() = default;
+  virtual ~Order();
 
   //stream insertion operator for printing orders
   friend std::ostream& operator<<(std::ostream& os, const Order& order);
 
   //static method to access negotiation records
   static void clearNegotiationRecords();
+
+  void saveEffect(const std::string& effectDescription);
+  std::string getEffect() const;
+  std::string stringToLog() const override;
 
 protected:
   // Needs to be cleared every turn in the game engine
@@ -41,6 +49,7 @@ protected:
   //order type and description
   std::string* type;
   std::string* description;
+  std::string* effect;
 
 };
 
@@ -134,7 +143,7 @@ public:
   Order* clone() const override;
 };
 
-class OrdersList {
+class OrdersList : public Subject, public ILoggable {
 public:
   std::vector<Order*>* orders;
 
@@ -158,4 +167,7 @@ private:
 
   //helper functions for validating indices
   bool validateIndex(int index);
+  Order* lastAddedOrder;
+public:
+  std::string stringToLog() const override;
 };


### PR DESCRIPTION
- Implemented Observer-based logging (LoggingObserver, Subject, ILoggable) writing to gamelog.txt.
- Wired logging notifications into Command, CommandProcessor, OrdersList/Order::execute(), and GameEngine state transitions.
- Added testLoggingObserver() to demonstrate command, order, and state change logging.